### PR TITLE
feat(SOVA-2452): implement task list display and pagination

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,9 @@
+'use client';
+
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
 import { HeaderBar } from '@/components';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -12,6 +15,8 @@ const geistMono = Geist_Mono({
   subsets: ['latin'],
 });
 
+const queryClient = new QueryClient();
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -20,8 +25,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        <HeaderBar />
-        {children}
+        <QueryClientProvider client={queryClient}>
+          <HeaderBar />
+          {children}
+        </QueryClientProvider>
       </body>
     </html>
   );

--- a/src/app/todo-list/listTable/components/dropdown.tsx
+++ b/src/app/todo-list/listTable/components/dropdown.tsx
@@ -1,0 +1,23 @@
+import { FormControl, MenuItem, Select, SelectChangeEvent } from '@mui/material';
+import React from 'react';
+
+export function Dropdown({
+  value: propValue,
+  onChange,
+}: {
+  value?: number;
+  onChange?: (event: SelectChangeEvent<number>) => void;
+}) {
+  return (
+    <FormControl
+      fullWidth={false}
+      sx={{ width: 100, height: 'auto', backgroundColor: '#fff', borderRadius: 2 }}
+    >
+      <Select value={propValue} onChange={onChange} sx={{ borderRadius: 2 }}>
+        <MenuItem value={5}>5</MenuItem>
+        <MenuItem value={10}>10</MenuItem>
+        <MenuItem value={50}>50</MenuItem>
+      </Select>
+    </FormControl>
+  );
+}

--- a/src/app/todo-list/listTable/components/listTable.tsx
+++ b/src/app/todo-list/listTable/components/listTable.tsx
@@ -1,0 +1,65 @@
+'use client';
+import { useGetTaskStatus } from '@/hooks/todo-list';
+import { TaskRow } from '@/hooks/todo-list/type';
+import {
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from '@mui/material';
+import React from 'react';
+
+type Status = {
+  id: number;
+  name: string;
+};
+
+export function ListTable({ taskRows }: { taskRows: TaskRow[] }) {
+  const { status } = useGetTaskStatus();
+  const statusArray: Status[] = status as Status[];
+
+  return (
+    <TableContainer component={Paper}>
+      <Table sx={{ minWidth: 650 }} aria-label="simple table">
+        <TableHead>
+          <TableRow>
+            <TableCell sx={{ fontWeight: 'bold', fontSize: 20 }}>Title</TableCell>
+            <TableCell align="left" sx={{ fontWeight: 'bold', fontSize: 20 }}>
+              Status
+            </TableCell>
+            <TableCell align="left" sx={{ fontWeight: 'bold', fontSize: 20 }}>
+              Description
+            </TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {taskRows?.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={3} align="center">
+                No result
+              </TableCell>
+            </TableRow>
+          ) : (
+            taskRows?.map((row) => (
+              <TableRow key={row.name} sx={{ '&:last-child td, &:last-child th': { border: 0 } }}>
+                <TableCell component={'th'} scope="row">
+                  {row.name}
+                </TableCell>
+                <TableCell align="left">
+                  {(() => {
+                    const name = statusArray.find((s) => s.id === row.statusId)?.name;
+                    return name ? name.charAt(0).toUpperCase() + name.slice(1) : row.statusId;
+                  })()}
+                </TableCell>
+                <TableCell align="left">{row.description}</TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/src/app/todo-list/listTable/components/todoListPagination.tsx
+++ b/src/app/todo-list/listTable/components/todoListPagination.tsx
@@ -1,0 +1,21 @@
+import { Box, Pagination, PaginationProps } from '@mui/material';
+import React from 'react';
+
+type BasePaginationProps = PaginationProps;
+
+export function TodoListPagination({ ...props }: BasePaginationProps) {
+  return (
+    <Box mt={2} display="flex" justifyContent="center" alignItems="flex-start">
+      <Pagination
+        {...props}
+        variant="outlined"
+        color="primary"
+        sx={{
+          '& .MuiPaginationItem-root': {
+            color: 'white',
+          },
+        }}
+      ></Pagination>
+    </Box>
+  );
+}

--- a/src/app/todo-list/listTable/page.tsx
+++ b/src/app/todo-list/listTable/page.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import { Container, SelectChangeEvent } from '@mui/material';
+import { TodoListPagination } from './components/todoListPagination';
+import { ListTable } from './components/listTable';
+import { useState } from 'react';
+import { Dropdown } from './components/dropdown';
+import { useGetTasks } from '@/hooks/todo-list';
+
+export default function Page() {
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+  const { tasks } = useGetTasks({ page: currentPage, size: pageSize });
+  const pageCount = Math.ceil((tasks?.total ?? 0) / pageSize) || 1;
+
+  return (
+    <Container sx={{ alignItems: 'flex-start', minHeight: '100vh' }}>
+      <Box
+        mt={8}
+        p={4}
+        bgcolor="#ffffff"
+        borderRadius={2}
+        justifyContent="center"
+        alignItems="flex-start"
+        width="auto"
+        height="auto"
+        minHeight="80vh"
+      >
+        <ListTable taskRows={tasks?.data ?? []} />
+      </Box>
+      <Box mx="auto" display="flex" alignItems="center" mt={2}>
+        <Box flex={1} display="flex" justifyContent="center">
+          <TodoListPagination count={pageCount} onChange={(_, value) => setCurrentPage(value)} />
+        </Box>
+        <Box ml="auto">
+          <Dropdown
+            value={pageSize}
+            onChange={(event: SelectChangeEvent<number>) => setPageSize(Number(event.target.value))}
+          />
+        </Box>
+      </Box>
+    </Container>
+  );
+}

--- a/src/hooks/todo-list/type.ts
+++ b/src/hooks/todo-list/type.ts
@@ -1,6 +1,7 @@
 export type Status = {
   id: number;
   name: string;
+}
 
 export type TaskRow = {
   name: string;

--- a/src/hooks/todo-list/type.ts
+++ b/src/hooks/todo-list/type.ts
@@ -1,4 +1,16 @@
 export type Status = {
   id: number;
   name: string;
+
+export type TaskRow = {
+  name: string;
+  statusId: number;
+  description: string;
+};
+
+export type TaskResponse = {
+  data: TaskRow[];
+  page: number;
+  size: number;
+  total: number;
 };

--- a/src/hooks/todo-list/useGetTasks.ts
+++ b/src/hooks/todo-list/useGetTasks.ts
@@ -1,23 +1,26 @@
-import axios from "axios";
-import { useCallback, useEffect, useState } from "react";
-import { BASE_URL } from "./constant";
+import axios from 'axios';
+import { BASE_URL } from './constant';
+import { useQuery } from '@tanstack/react-query';
+import { TaskResponse } from './type';
 
+export function useGetTasks(params: { name?: string; page?: number; size?: number } = {}) {
+  const { name = '', page = 1, size = 10 } = params;
 
-export function useGetTasks() {
-  const [tasks, setTasks] = useState<any[]>([]);
+  const { data, isLoading, isError, error } = useQuery<TaskResponse>({
+    queryKey: ['tasks', name, page, size],
+    queryFn: async () => {
+      const result = await axios.get<TaskResponse>(`${BASE_URL}/api/task`, {
+        params: { name, page, size },
+      });
+      const raw = result.data;
+      return raw;
+    },
+  });
 
-  const fetchTasks = useCallback(async () => {
-    try {
-      const result = await axios.get(`${BASE_URL}/api/task`);
-      setTasks(result.data);
-    } catch (err) {
-      console.error('Error fetching tasks:', err);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchTasks();
-  }, [fetchTasks]);
-
-  return { tasks };
+  return {
+    tasks: data,
+    isLoading,
+    isError,
+    error,
+  };
 }


### PR DESCRIPTION
顯示後端所有 task 在 list view 上
且能用 pagination 調整切頁
plus 用 dropdown 調整每頁顯示數量

- 調整 get all tasks api 為可帶 query string 的形式
- 以取得的資料決定要顯示的頁數
- 切換頁資料正確顯示
- 切換 dropdown 數量時 page 數會更新 且顯示正確

測試結果如下

base on : 
- #3 

![image](https://github.com/user-attachments/assets/18202670-1e44-4fed-8b2d-ba301ee7253b)

![image](https://github.com/user-attachments/assets/23a4a091-9353-4b0e-aa22-b0621cce99aa)

![image](https://github.com/user-attachments/assets/a10f6acd-bb93-412f-947a-7b08998b0ef4)


